### PR TITLE
Fix lithium 0.14 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,5 @@ maven_group=dev.kikugie
 archives_base_name=shulkerfix
 
 # Dependencies
-lithium=mc1.21.1-0.13.1
+lithium=mc1.21.1-0.14.0-beta.1
 carpet=5425253

--- a/src/main/java/dev/kikugie/shulkerfix/mixin/compat/LithiumHopperHelperMixin.java
+++ b/src/main/java/dev/kikugie/shulkerfix/mixin/compat/LithiumHopperHelperMixin.java
@@ -3,14 +3,13 @@ package dev.kikugie.shulkerfix.mixin.compat;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.kikugie.shulkerfix.Util;
-import net.caffeinemc.mods.lithium.common.hopper.HopperHelper;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Pseudo
-@Mixin(value = HopperHelper.class)
+@Mixin(targets = {"net.caffeinemc.mods.lithium.common.hopper.HopperHelper", "me.jellysquid.mods.lithium.common.hopper.HopperHelper"})
 public class LithiumHopperHelperMixin {
 	@SuppressWarnings("UnresolvedMixinReference")
 	@WrapOperation(

--- a/src/main/java/dev/kikugie/shulkerfix/mixin/compat/LithiumHopperHelperMixin.java
+++ b/src/main/java/dev/kikugie/shulkerfix/mixin/compat/LithiumHopperHelperMixin.java
@@ -3,7 +3,7 @@ package dev.kikugie.shulkerfix.mixin.compat;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.kikugie.shulkerfix.Util;
-import me.jellysquid.mods.lithium.common.hopper.HopperHelper;
+import net.caffeinemc.mods.lithium.common.hopper.HopperHelper;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;

--- a/src/main/java/dev/kikugie/shulkerfix/mixin/compat/LithiumStackListMixin.java
+++ b/src/main/java/dev/kikugie/shulkerfix/mixin/compat/LithiumStackListMixin.java
@@ -3,14 +3,13 @@ package dev.kikugie.shulkerfix.mixin.compat;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.kikugie.shulkerfix.Util;
-import net.caffeinemc.mods.lithium.common.hopper.LithiumStackList;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Pseudo
-@Mixin(LithiumStackList.class)
+@Mixin(targets = {"net.caffeinemc.mods.lithium.common.hopper.LithiumStackList", "me.jellysquid.mods.lithium.common.hopper.LithiumStackList"})
 public class LithiumStackListMixin {
 	@WrapOperation(
 		method = "calculateSignalStrength",

--- a/src/main/java/dev/kikugie/shulkerfix/mixin/compat/LithiumStackListMixin.java
+++ b/src/main/java/dev/kikugie/shulkerfix/mixin/compat/LithiumStackListMixin.java
@@ -3,7 +3,7 @@ package dev.kikugie.shulkerfix.mixin.compat;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.kikugie.shulkerfix.Util;
-import me.jellysquid.mods.lithium.common.hopper.LithiumStackList;
+import net.caffeinemc.mods.lithium.common.hopper.LithiumStackList;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
@@ -16,7 +16,7 @@ public class LithiumStackListMixin {
 		method = "calculateSignalStrength",
 		at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getMaxCount()I")
 	)
-	private int get1(ItemStack instance, Operation<Integer> original) {
+	private int modifyShulkerMaxCount(ItemStack instance, Operation<Integer> original) {
 		return Util.isShulkerBoxLimited(instance) ? 1 : original.call(instance);
 	}
 }


### PR DESCRIPTION
Lithium 0.14 changes the package name so the rules doesn't work, you can wait until the stable version of lithium 0.14 is released before merging.