### PR TITLE
Fix mixin target on <1.21.2

### DIFF
--- a/src/main/java/dev/kikugie/shulkerfix/mixin/StorageMinecartEntityMixin.java
+++ b/src/main/java/dev/kikugie/shulkerfix/mixin/StorageMinecartEntityMixin.java
@@ -16,7 +16,7 @@ public class StorageMinecartEntityMixin {
 	@SuppressWarnings({"UnresolvedMixinReference", "UnnecessaryQualifiedMemberReference"})
 	@ModifyArg(
 		method = {
-			"Lnet/minecraft/entity/vehicle/StorageMinecartEntity;applySlowdown()V", // <1.21.2
+			"Lnet/minecraft/class_1693;method_7525()V", // <1.21.2
 			"Lnet/minecraft/entity/vehicle/StorageMinecartEntity;applySlowdown(Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/Vec3d;"
 		},
 		at = @At(


### PR DESCRIPTION
StorageMinecartEntity.applySlowdown() is no longer exists after 1.21.3, so the mappings can't affect it. I replaced it with the remapped one.